### PR TITLE
Add in-memory cache + reduce the size of results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "python.defaultInterpreterPath": "./venv/bin/python",
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.codeActionsOnSave": {
       "source.organizeImports": "never"
     }


### PR DESCRIPTION
**Reason:**
1. In-memory cache - to improve the latency of tool calls (this is for non production use case only)
2. Reduced size of API responses - to reduce the amount of content the LLM will have to keep track in its state - removed the fields we were not using